### PR TITLE
Change static lodash import to require

### DIFF
--- a/ts/operations.ts
+++ b/ts/operations.ts
@@ -1,6 +1,7 @@
-import * as isPlainObject from 'lodash/isPlainObject'
 import { UserLogic } from 'user-logic'
 import { typedValueTemplate } from './user-logic'
+
+const isPlainObject = require('lodash/isPlainObject')
 
 export function renderOperationArgs(operation, vars) {
     if (isPlainObject(operation)) {


### PR DESCRIPTION
- fixes runtime issue where `isPlainObject` is always `undefined` when memex includes this package in its build
- sadly, I cannot explain why this fixes it